### PR TITLE
fix: precision ceil for negative numbers

### DIFF
--- a/src/__tests__/precision.test.ts
+++ b/src/__tests__/precision.test.ts
@@ -136,6 +136,15 @@ describe('unsafeSetPrecision()', () => {
       precision: 1,
     });
   });
+  it('returns a monetary value (negative) with a matching amount up to the relevant digit when provided a lower precision', () => {
+    expect(
+      unsafeSetPrecision({ amount: -314, currency: 'EUR', precision: 2 }, 1),
+    ).toBeIdenticalToMonetaryValue({
+      amount: -31,
+      currency: 'EUR',
+      precision: 1,
+    });
+  });
   it('returns a monetary value with a matching amount up to the relevant digit, rounded according to the provided rounding function, when provided a lower precision', () => {
     expect(
       unsafeSetPrecision(

--- a/src/precision.ts
+++ b/src/precision.ts
@@ -96,7 +96,10 @@ export function unsafeSetPrecision<C extends string>(
 ): MonetaryValue<C> {
   if (monetaryValue.precision >= precision) {
     const divider = pow10(monetaryValue.precision - precision);
-    const wholePart = Math.floor(monetaryValue.amount / divider);
+    const wholePart =
+      monetaryValue.amount < 0
+        ? Math.ceil(monetaryValue.amount / divider)
+        : Math.floor(monetaryValue.amount / divider);
     const numerator = monetaryValue.amount % divider;
     return {
       amount: roundingFunction(wholePart, numerator, divider),


### PR DESCRIPTION
the difference between positive and negative numbers is causing an error for the return values of setPrecision.
we should use floor for positive numbers and ceiling for negative numbers


i think we may have the same problem for unsafeIntegerDivide https://github.com/Spendesk/ezmoney/blob/01fb1305789dee532448c3adf2292b4c24b387ec/src/operations/misc.ts#L103
i will need some pair prog help to update the tests there.