### PR TITLE
fix: rounding errors negative values

### DIFF
--- a/src/operations/misc.ts
+++ b/src/operations/misc.ts
@@ -105,7 +105,7 @@ export function unsafeIntegerDivide<C extends string>(
   divider: number,
   roundingFunction: RoundingFunction = roundHalfToEven,
 ): MonetaryValue<C> {
-  const wholePart = Math.floor(monetaryValue.amount / divider);
+  const wholePart = Math.trunc(monetaryValue.amount / divider);
   const numerator = monetaryValue.amount % divider;
   return {
     amount: roundingFunction(wholePart, numerator, divider),


### PR DESCRIPTION
`multiply`, `unsafeMultiply`, `integerDivide`, and `unsafeIntegerDivide` were all vulnerable to off-by-one errors when working with negative numerators as `Math.floor(1.1) == 1` but `Math.floor(-1.1) == -2`. Replaced the `floor` with `trunc` and evaluated all other uses of `Math.floor` and `Math.ceil`, they all look safe ☺️ 