### PR TITLE
fix: rounding inconsistency for negative values in math.allocate

### DIFF
--- a/src/utils/__tests__/math.test.ts
+++ b/src/utils/__tests__/math.test.ts
@@ -117,4 +117,7 @@ describe('allocate()', () => {
   it('returns an array that distributes the provided number to each weight, using the negative weights to increase the amount that can be allocated', () => {
     expect(allocate(100, [-5, 15], 10)).toEqual([-50, 150]);
   });
+  it('returns the same distributions with negative and positive values', () => {
+    expect(allocate(21, [1, 5, 4], 10).map((value) => Math.abs(value))).toEqual(allocate(-21, [1, 5, 4], 10).map((value) => Math.abs(value)))
+  });
 });

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -89,7 +89,7 @@ export function allocate(
   let i = 0;
   while (i < length - 1) {
     const share = (weights[i] / total) * n + crumbs;
-    const wholeShare = Math.floor(share);
+    const wholeShare = Math.trunc(share);
     crumbs = share - wholeShare;
     sum += wholeShare;
     shares[i] = wholeShare;


### PR DESCRIPTION
follow up to [PR#72](https://github.com/Spendesk/ezmoney/pull/72), although `math.allocate` does not result in incorrect distributions due to `Math.floor` usage, it was inconsistent in behaviour between negative and positive. Corrected this using the same fix as before, `Math.trunc` when trying to figure out the "whole" part of a number